### PR TITLE
Transaction Context Menu

### DIFF
--- a/src/lib/components/reusable-fields/form-amount-field.svelte
+++ b/src/lib/components/reusable-fields/form-amount-field.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	let {input = "0"} = $props();
-	let value = $state(Number(input)*100);
+	let { input = '0' } = $props();
+	let value = $state(Number(input) * 100);
 	let formattedValue = $derived((value / 100).toFixed(2));
 	let componentId = $props.id();
 	let isFocused = $state(false);

--- a/src/lib/components/reusable-fields/form-amount-field.svelte
+++ b/src/lib/components/reusable-fields/form-amount-field.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	let value = $state(0);
+	let {input = "0"} = $props();
+	let value = $state(Number(input)*100);
 	let formattedValue = $derived((value / 100).toFixed(2));
 	let componentId = $props.id();
 	let isFocused = $state(false);

--- a/src/lib/components/reusable-fields/form-name-field.svelte
+++ b/src/lib/components/reusable-fields/form-name-field.svelte
@@ -1,9 +1,10 @@
 <script>
 	import { Input } from '../ui/input';
 	import { Label } from '../ui/label';
+	let {input = ""} = $props();
 </script>
 
 <div class="flex flex-col gap-3">
 	<Label>Name</Label>
-	<Input name="name" />
+	<Input name="name" value={input}/>
 </div>

--- a/src/lib/components/reusable-fields/form-name-field.svelte
+++ b/src/lib/components/reusable-fields/form-name-field.svelte
@@ -1,10 +1,10 @@
 <script>
 	import { Input } from '../ui/input';
 	import { Label } from '../ui/label';
-	let {input = ""} = $props();
+	let { input = '' } = $props();
 </script>
 
 <div class="flex flex-col gap-3">
 	<Label>Name</Label>
-	<Input name="name" value={input}/>
+	<Input name="name" value={input} />
 </div>

--- a/src/lib/components/transaction/delete-transaction-dialog.svelte
+++ b/src/lib/components/transaction/delete-transaction-dialog.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import { deleteTransaction, getTransactionByWeek } from '$lib/remote/transaction.remote';
+	let {
+		forWeek,
+		id,
+		name,
+		open = $bindable()
+	}: { forWeek: Date; id: string; name: string; open: boolean } = $props();
+	const deleteIt = async () => {
+		await deleteTransaction({ id }).updates(getTransactionByWeek(forWeek));
+		open = false;
+	};
+</script>
+
+<Dialog.Root
+	{open}
+	onOpenChange={() => {
+		open = !open;
+	}}
+>
+	<Dialog.Content class="max-w-[425px]">
+		<Dialog.Header>
+			<Dialog.Title>Delete Transaction | {name}</Dialog.Title>
+			<Dialog.Description>
+				Deleting this transaction is permanent and cannot be undone!
+			</Dialog.Description>
+		</Dialog.Header>
+		<Dialog.Footer>
+			<Button
+				variant="link"
+				onclick={() => {
+					open = false;
+				}}>Cancel</Button
+			>
+			<Button
+				variant="link"
+				class="text-destructive"
+				onclick={() => {
+					deleteIt();
+				}}>Delete</Button
+			>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/transaction/edit-transaction-drawer.svelte
+++ b/src/lib/components/transaction/edit-transaction-drawer.svelte
@@ -2,13 +2,14 @@
 	import * as Drawer from '$lib/components/ui/drawer';
 
 	import FormAmountField from '../reusable-fields/form-amount-field.svelte';
+	import FormNameField from '../reusable-fields/form-name-field.svelte';
 	import { Button } from '../ui/button';
 	import EditTransactionForm from './edit-transaction-form.svelte';
-	import EditBudgetForm from './edit-transaction-form.svelte';
 
 	export type Transaction = {
 		amount: string;
-		name: string
+		name: string;
+		id: string
 	}
 
 	let {
@@ -23,7 +24,7 @@
 	<Drawer.Content class="border-none bg-transparent">
 		<!-- BG Override -->
 		<div class="mt-2 rounded-t-3xl border-t bg-background">
-			<EditTransactionForm bind:drawerOpen={open}>
+			<EditTransactionForm bind:drawerOpen={open} id={transaction.id}>
 				<div class="flex items-center justify-between p-2 pt-3">
 					<Drawer.Close>
 						{#snippet child({ props })}
@@ -31,12 +32,13 @@
 						{/snippet}
 					</Drawer.Close>
 					<span class="absolute left-1/2 -translate-x-1/2 transform text-lg font-bold"
-						>Edit Transaction | {transaction.name}</span
+						>{transaction.name}</span
 					>
 					<Button variant="link" class="text-lg font-bold" type="submit">Done</Button>
 				</div>
 				<div class="mb-24 flex flex-col gap-6 px-6">
-					<FormAmountField />
+					<FormAmountField input={transaction.amount} />
+					<FormNameField input={transaction.name} />
 				</div>
 			</EditTransactionForm>
 		</div>

--- a/src/lib/components/transaction/edit-transaction-drawer.svelte
+++ b/src/lib/components/transaction/edit-transaction-drawer.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import * as Drawer from '$lib/components/ui/drawer';
+
+	import FormAmountField from '../reusable-fields/form-amount-field.svelte';
+	import { Button } from '../ui/button';
+	import EditTransactionForm from './edit-transaction-form.svelte';
+	import EditBudgetForm from './edit-transaction-form.svelte';
+
+	export type Transaction = {
+		amount: string;
+		name: string
+	}
+
+	let {
+		open = $bindable(), transaction
+	}: {
+		open: boolean;
+		transaction: Transaction
+	} = $props();
+</script>
+
+<Drawer.Root bind:open>
+	<Drawer.Content class="border-none bg-transparent">
+		<!-- BG Override -->
+		<div class="mt-2 rounded-t-3xl border-t bg-background">
+			<EditTransactionForm bind:drawerOpen={open}>
+				<div class="flex items-center justify-between p-2 pt-3">
+					<Drawer.Close>
+						{#snippet child({ props })}
+							<Button variant="link" type="button" class="text-lg" {...props}>Cancel</Button>
+						{/snippet}
+					</Drawer.Close>
+					<span class="absolute left-1/2 -translate-x-1/2 transform text-lg font-bold"
+						>Edit Transaction | {transaction.name}</span
+					>
+					<Button variant="link" class="text-lg font-bold" type="submit">Done</Button>
+				</div>
+				<div class="mb-24 flex flex-col gap-6 px-6">
+					<FormAmountField />
+				</div>
+			</EditTransactionForm>
+		</div>
+	</Drawer.Content>
+</Drawer.Root>

--- a/src/lib/components/transaction/edit-transaction-drawer.svelte
+++ b/src/lib/components/transaction/edit-transaction-drawer.svelte
@@ -1,22 +1,19 @@
 <script lang="ts">
 	import * as Drawer from '$lib/components/ui/drawer';
 
+	import type { Transaction } from './transaction-list.svelte';
+
 	import FormAmountField from '../reusable-fields/form-amount-field.svelte';
 	import FormNameField from '../reusable-fields/form-name-field.svelte';
 	import { Button } from '../ui/button';
 	import EditTransactionForm from './edit-transaction-form.svelte';
 
-	export type Transaction = {
-		amount: string;
-		name: string;
-		id: string
-	}
-
 	let {
-		open = $bindable(), transaction
+		open = $bindable(),
+		transaction
 	}: {
 		open: boolean;
-		transaction: Transaction
+		transaction: Transaction;
 	} = $props();
 </script>
 

--- a/src/lib/components/transaction/edit-transaction-form.svelte
+++ b/src/lib/components/transaction/edit-transaction-form.svelte
@@ -1,0 +1,37 @@
+<script lang="ts" module>
+	export const changeTransactionSchema = z.object({
+		id: z.string(),
+		amount: z.string().refine((amount) => !isNaN(Number(amount))),
+		name: z.string()
+	});
+</script>
+
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import { changeTransaction } from '$lib/remote/transaction.remote';
+	import { getSelectedWeekContext } from '$lib/state/selected-week.svelte';
+	import z from 'zod';
+	let {
+		children,
+		drawerOpen = $bindable()
+	}: { children: Snippet; drawerOpen: boolean; id?: string } = $props();
+
+	const selectedWeek = getSelectedWeekContext();
+</script>
+
+<form
+	{...changeTransaction.enhance(async ({ submit }) => {
+		try {
+			// Client side form validation...
+			// await submit().updates(getBudgetByAppliesTo(selectedWeek.nativeDate));
+			await submit();
+			drawerOpen = false;
+		} catch {
+			console.error('something went wrong');
+		}
+	})}
+>
+	<input type="hidden" name="appliesTo" value={selectedWeek.nativeDate} />
+	{@render children()}
+</form>

--- a/src/lib/components/transaction/edit-transaction-form.svelte
+++ b/src/lib/components/transaction/edit-transaction-form.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
 	export const changeTransactionSchema = z.object({
-		id: z.string(),
 		amount: z.string().refine((amount) => !isNaN(Number(amount))),
+		id: z.string(),
 		name: z.string()
 	});
 </script>

--- a/src/lib/components/transaction/edit-transaction-form.svelte
+++ b/src/lib/components/transaction/edit-transaction-form.svelte
@@ -10,14 +10,12 @@
 	import type { Snippet } from 'svelte';
 
 	import { changeTransaction } from '$lib/remote/transaction.remote';
-	import { getSelectedWeekContext } from '$lib/state/selected-week.svelte';
 	import z from 'zod';
 	let {
 		children,
-		drawerOpen = $bindable()
-	}: { children: Snippet; drawerOpen: boolean; id?: string } = $props();
-
-	const selectedWeek = getSelectedWeekContext();
+		drawerOpen = $bindable(),
+		id
+	}: { children: Snippet; drawerOpen: boolean; id: string } = $props();
 </script>
 
 <form
@@ -27,11 +25,11 @@
 			// await submit().updates(getBudgetByAppliesTo(selectedWeek.nativeDate));
 			await submit();
 			drawerOpen = false;
-		} catch {
-			console.error('something went wrong');
+		} catch (e) {
+			console.error('something went wrong', e);
 		}
 	})}
 >
-	<input type="hidden" name="appliesTo" value={selectedWeek.nativeDate} />
+	<input type="hidden" name="id" value={id} />
 	{@render children()}
 </form>

--- a/src/lib/components/transaction/transaction-context-menu.svelte
+++ b/src/lib/components/transaction/transaction-context-menu.svelte
@@ -2,10 +2,16 @@
 	import type { Snippet } from 'svelte';
 
 	import PencilIcon from '@lucide/svelte/icons/pencil';
+	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import * as ContextMenu from '$lib/components/ui/context-menu';
-	import EditTransactionDrawer, { type Transaction } from './edit-transaction-drawer.svelte';
 
-	let open = $state(false);
+	import type { Transaction } from './transaction-list.svelte';
+
+	import DeleteTransactionDialog from './delete-transaction-dialog.svelte';
+	import EditTransactionDrawer from './edit-transaction-drawer.svelte';
+
+	let openEdit = $state(false);
+	let openDelete = $state(false);
 
 	let {
 		child,
@@ -20,7 +26,7 @@
 					]
 			  >
 			| undefined;
-			transaction: Transaction
+		transaction: Transaction;
 	} = $props();
 </script>
 
@@ -30,11 +36,15 @@
 		<ContextMenu.Label>{transaction.name}</ContextMenu.Label>
 		<ContextMenu.Separator />
 
-		<ContextMenu.Item onclick={() => (open = true)}>
+		<ContextMenu.Item onclick={() => (openEdit = true)}>
 			<PencilIcon />
-			Edit Transaction</ContextMenu.Item
+			Edit</ContextMenu.Item
 		>
+		<ContextMenu.Item onclick={() => (openDelete = true)}>
+			<TrashIcon />Delete
+		</ContextMenu.Item>
 	</ContextMenu.Content>
 </ContextMenu.Root>
 
-<EditTransactionDrawer bind:open {transaction}/>
+<EditTransactionDrawer bind:open={openEdit} {transaction} />
+<DeleteTransactionDialog bind:open={openDelete} {...transaction} />

--- a/src/lib/components/transaction/transaction-context-menu.svelte
+++ b/src/lib/components/transaction/transaction-context-menu.svelte
@@ -27,7 +27,7 @@
 <ContextMenu.Root>
 	<ContextMenu.Trigger {child}></ContextMenu.Trigger>
 	<ContextMenu.Content>
-		<ContextMenu.Label>Total Budget</ContextMenu.Label>
+		<ContextMenu.Label>{transaction.name}</ContextMenu.Label>
 		<ContextMenu.Separator />
 
 		<ContextMenu.Item onclick={() => (open = true)}>

--- a/src/lib/components/transaction/transaction-context-menu.svelte
+++ b/src/lib/components/transaction/transaction-context-menu.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import PencilIcon from '@lucide/svelte/icons/pencil';
+	import * as ContextMenu from '$lib/components/ui/context-menu';
+	import EditTransactionDrawer, { type Transaction } from './edit-transaction-drawer.svelte';
+
+	let open = $state(false);
+
+	let {
+		child,
+		transaction
+	}: {
+		child?:
+			| Snippet<
+					[
+						{
+							props: Record<string, unknown>;
+						}
+					]
+			  >
+			| undefined;
+			transaction: Transaction
+	} = $props();
+</script>
+
+<ContextMenu.Root>
+	<ContextMenu.Trigger {child}></ContextMenu.Trigger>
+	<ContextMenu.Content>
+		<ContextMenu.Label>Total Budget</ContextMenu.Label>
+		<ContextMenu.Separator />
+
+		<ContextMenu.Item onclick={() => (open = true)}>
+			<PencilIcon />
+			Edit Transaction</ContextMenu.Item
+		>
+	</ContextMenu.Content>
+</ContextMenu.Root>
+
+<EditTransactionDrawer bind:open {transaction}/>

--- a/src/lib/components/transaction/transaction-list.svelte
+++ b/src/lib/components/transaction/transaction-list.svelte
@@ -1,3 +1,14 @@
+<script lang="ts" module>
+	export type Transaction = {
+		amount: string;
+		forWeek: Date;
+		id: string;
+		name: string;
+		paidAt: Date;
+		user: string;
+	};
+</script>
+
 <script lang="ts">
 	import * as Card from '$lib/components/ui/card';
 	import { getTransactionByWeek } from '$lib/remote/transaction.remote';
@@ -6,14 +17,6 @@
 	import { Badge } from '../ui/badge';
 	import { Skeleton } from '../ui/skeleton';
 	import TransactionContextMenu from './transaction-context-menu.svelte';
-
-	type Transaction = {
-		amount: string;
-		id: string;
-		name: string;
-		paidAt: Date;
-		user: string;
-	};
 
 	// [TODO] Change this query to use svelte:boundary and await
 	// Wait for this issue to resolve: https://github.com/sveltejs/kit/issues/14113
@@ -34,7 +37,7 @@
 	<ul class="flex flex-col gap-2">
 		{#each query.current as transaction (transaction.id)}
 			<TransactionContextMenu {transaction}>
-				{#snippet child({props})}
+				{#snippet child({ props })}
 					<div {...props}>{@render card(transaction)}</div>
 				{/snippet}
 			</TransactionContextMenu>

--- a/src/lib/components/transaction/transaction-list.svelte
+++ b/src/lib/components/transaction/transaction-list.svelte
@@ -5,6 +5,7 @@
 
 	import { Badge } from '../ui/badge';
 	import { Skeleton } from '../ui/skeleton';
+	import TransactionContextMenu from './transaction-context-menu.svelte';
 
 	type Transaction = {
 		amount: string;
@@ -32,7 +33,11 @@
 {:else}
 	<ul class="flex flex-col gap-2">
 		{#each query.current as transaction (transaction.id)}
-			{@render card(transaction)}
+			<TransactionContextMenu {transaction}>
+				{#snippet child({props})}
+					<div {...props}>{@render card(transaction)}</div>
+				{/snippet}
+			</TransactionContextMenu>
 		{/each}
 	</ul>
 {/if}

--- a/src/lib/components/ui/dialog/dialog-close.svelte
+++ b/src/lib/components/ui/dialog/dialog-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: DialogPrimitive.CloseProps = $props();
+</script>
+
+<DialogPrimitive.Close bind:ref data-slot="dialog-close" {...restProps} />

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import XIcon from '@lucide/svelte/icons/x';
+	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	import * as Dialog from './index.js';
+
+	let {
+		children,
+		class: className,
+		portalProps,
+		ref = $bindable(null),
+		showCloseButton = true,
+		...restProps
+	}: {
+		children: Snippet;
+		portalProps?: DialogPrimitive.PortalProps;
+		showCloseButton?: boolean;
+	} & WithoutChildrenOrChild<DialogPrimitive.ContentProps> = $props();
+</script>
+
+<Dialog.Portal {...portalProps}>
+	<Dialog.Overlay />
+	<DialogPrimitive.Content
+		bind:ref
+		data-slot="dialog-content"
+		class={cn(
+			'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		{#if showCloseButton}
+			<DialogPrimitive.Close
+				class="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+			>
+				<XIcon />
+				<span class="sr-only">Close</span>
+			</DialogPrimitive.Close>
+		{/if}
+	</DialogPrimitive.Content>
+</Dialog.Portal>

--- a/src/lib/components/ui/dialog/dialog-description.svelte
+++ b/src/lib/components/ui/dialog/dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let {
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: DialogPrimitive.DescriptionProps = $props();
+</script>
+
+<DialogPrimitive.Description
+	bind:ref
+	data-slot="dialog-description"
+	class={cn('text-sm text-muted-foreground', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		children,
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="dialog-footer"
+	class={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/src/lib/components/ui/dialog/dialog-header.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	let {
+		children,
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="dialog-header"
+	class={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let {
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: DialogPrimitive.OverlayProps = $props();
+</script>
+
+<DialogPrimitive.Overlay
+	bind:ref
+	data-slot="dialog-overlay"
+	class={cn(
+		'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/src/lib/components/ui/dialog/dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let {
+		class: className,
+		ref = $bindable(null),
+		...restProps
+	}: DialogPrimitive.TitleProps = $props();
+</script>
+
+<DialogPrimitive.Title
+	bind:ref
+	data-slot="dialog-title"
+	class={cn('text-lg leading-none font-semibold', className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-trigger.svelte
+++ b/src/lib/components/ui/dialog/dialog-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from 'bits-ui';
+
+	let { ref = $bindable(null), ...restProps }: DialogPrimitive.TriggerProps = $props();
+</script>
+
+<DialogPrimitive.Trigger bind:ref data-slot="dialog-trigger" {...restProps} />

--- a/src/lib/components/ui/dialog/index.ts
+++ b/src/lib/components/ui/dialog/index.ts
@@ -1,0 +1,37 @@
+import { Dialog as DialogPrimitive } from 'bits-ui';
+
+import Close from './dialog-close.svelte';
+import Content from './dialog-content.svelte';
+import Description from './dialog-description.svelte';
+import Footer from './dialog-footer.svelte';
+import Header from './dialog-header.svelte';
+import Overlay from './dialog-overlay.svelte';
+import Title from './dialog-title.svelte';
+import Trigger from './dialog-trigger.svelte';
+
+const Root = DialogPrimitive.Root;
+const Portal = DialogPrimitive.Portal;
+
+export {
+	Close,
+	Content,
+	Description,
+	//
+	Root as Dialog,
+	Close as DialogClose,
+	Content as DialogContent,
+	Description as DialogDescription,
+	Footer as DialogFooter,
+	Header as DialogHeader,
+	Overlay as DialogOverlay,
+	Portal as DialogPortal,
+	Title as DialogTitle,
+	Trigger as DialogTrigger,
+	Footer,
+	Header,
+	Overlay,
+	Portal,
+	Root,
+	Title,
+	Trigger
+};

--- a/src/lib/remote/transaction.remote.ts
+++ b/src/lib/remote/transaction.remote.ts
@@ -1,5 +1,6 @@
-import { form, query } from '$app/server';
+import { command, form, query } from '$app/server';
 import { addTransactionSchema } from '$lib/components/transaction/add-transaction-form.svelte';
+import { changeTransactionSchema } from '$lib/components/transaction/edit-transaction-form.svelte';
 import { ERRORS } from '$lib/server/errors';
 import { DBService } from '$lib/server/service/db';
 import { LocalsService } from '$lib/server/service/locals';
@@ -19,6 +20,19 @@ export const createNewTransaction = form(async (formData) => {
 
 	await dbService.insertTransaction({ ...result.data, user: localsService.validateSession().user });
 });
+
+export const changeTransaction = form(async (formData) => {
+	const data = Object.fromEntries(formData.entries());
+	
+	const validateResult = changeTransactionSchema.safeParse(data);
+
+	if (!validateResult.success) {
+		return ERRORS.BAD_REQUEST();
+	}
+	const dbService = new DBService();
+
+	await dbService.updateTransaction(validateResult.data);
+})
 
 export const getTransactionByWeek = query(z.date(), async (date) => {
 	// await sleep();

--- a/src/lib/remote/transaction.remote.ts
+++ b/src/lib/remote/transaction.remote.ts
@@ -23,7 +23,7 @@ export const createNewTransaction = form(async (formData) => {
 
 export const changeTransaction = form(async (formData) => {
 	const data = Object.fromEntries(formData.entries());
-	
+
 	const validateResult = changeTransactionSchema.safeParse(data);
 
 	if (!validateResult.success) {
@@ -32,7 +32,14 @@ export const changeTransaction = form(async (formData) => {
 	const dbService = new DBService();
 
 	await dbService.updateTransaction(validateResult.data);
-})
+});
+
+export const deleteTransaction = command(z.object({ id: z.string() }), async ({ id }) => {
+	const dbService = new DBService();
+
+	const transaction = await dbService.deleteTransaction(id);
+	if (transaction.length > 0) await getTransactionByWeek(transaction[0].forWeek).refresh();
+});
 
 export const getTransactionByWeek = query(z.date(), async (date) => {
 	// await sleep();

--- a/src/lib/server/service/db.ts
+++ b/src/lib/server/service/db.ts
@@ -116,4 +116,8 @@ export class DBService {
 	async updateSessionById({ id, ...data }: { expiresAt?: Date; id: string; user?: User }) {
 		return this.db.update(table.session).set(data).where(eq(table.session.id, id)).returning();
 	}
+
+	async updateTransaction({id, ...data}: {amount: string; id: string, name: string}) {
+		return this.db.update(table.transaction).set(data).where(eq(table.transaction.id, id));
+	}
 }

--- a/src/lib/server/service/db.ts
+++ b/src/lib/server/service/db.ts
@@ -14,6 +14,10 @@ export class DBService {
 		return await this.db.delete(table.session).where(eq(table.session.id, id)).returning();
 	}
 
+	async deleteTransaction(id: string) {
+		return await this.db.delete(table.transaction).where(eq(table.transaction.id, id)).returning();
+	}
+
 	async insertOrUpdateBudget(data: { amount: string; appliesTo: Date }) {
 		return await this.db
 			.insert(table.budget)
@@ -104,6 +108,7 @@ export class DBService {
 		return await this.db
 			.select({
 				amount: table.transaction.amount,
+				forWeek: table.transaction.forWeek,
 				id: table.transaction.id,
 				name: table.transaction.name,
 				paidAt: table.transaction.paidAt,
@@ -117,7 +122,7 @@ export class DBService {
 		return this.db.update(table.session).set(data).where(eq(table.session.id, id)).returning();
 	}
 
-	async updateTransaction({id, ...data}: {amount: string; id: string, name: string}) {
+	async updateTransaction({ id, ...data }: { amount: string; id: string; name: string }) {
 		return this.db.update(table.transaction).set(data).where(eq(table.transaction.id, id));
 	}
 }


### PR DESCRIPTION
Added a transaction context menu
you can now do the following:

- [x] Right click/long press over a transaction to see a context menu
- [x] Edit a transaction
- [x] Delete a transaction

Known issues, deleting a transaction does not remove it from transaction list until user refreshes